### PR TITLE
Missing year in the time stamps #178

### DIFF
--- a/_includes/post-featured.html
+++ b/_includes/post-featured.html
@@ -53,7 +53,7 @@
               
               <!-- Date -->
               <p class="h6 text-uppercase text-muted mb-0 ml-auto">
-                <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date: "%b %d" }}</time>
+                {%- include timestamp.html entity=post -%}
               </p>
 
             </a>

--- a/_includes/post-regular.html
+++ b/_includes/post-regular.html
@@ -46,7 +46,7 @@
         
         <!-- Date -->
         <p class="h6 text-uppercase text-muted mb-0 ml-auto">
-          <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date: "%b %d" }}</time>
+          {%- include timestamp.html entity=post -%}
         </p>
 
       </a>

--- a/_includes/timestamp.html
+++ b/_includes/timestamp.html
@@ -1,0 +1,3 @@
+<time datetime="{{ include.entity.date | date: "%Y-%m-%d" }}">
+    {{ include.preText }}{{ include.entity.date | date: "%b %d, %Y" }}{{ include.postText }}
+</time>

--- a/_layouts/blog-post.html
+++ b/_layouts/blog-post.html
@@ -31,9 +31,9 @@ layout: default
                 </h6>
 
                 <!-- Date -->
-                <time class="font-size-sm text-muted" datetime="{{ post.date | date: "%Y-%m-%d" }}">
-                  Published on {{ page.date | date: "%b %d, %Y" }}
-                </time>
+                <p class="font-size-sm text-muted">
+                  {%- include timestamp.html preText="Published on " entity=page -%}
+                </p>
 
               </div>
               <div class="col-auto">


### PR DESCRIPTION
- added `timestamp` include for consistency
- all places where timestamp used now uses include
- year added to timestamp