### PR TITLE
Missing tags #197

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 **/*.DS_Store
 node_modules
 .env
+.bundle/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,21 @@ e.g.
 ```
 ![alt text](/path/to/image.png#responsive)
 ```
+
+# How to add a new category
+
+- copy `/articles/experience/index.html` to `/articles/cheeseburgers/index.html`, e.g.
+
+```
+---
+layout: articles
+category:
+    name: Cheeseburgers
+    slug: cheeseburgers
+---
+
+{%- include category-section.html category=page.category -%}
+
+```
+
+- tag your new post with `cheeseburgers`

--- a/_includes/article-categories.html
+++ b/_includes/article-categories.html
@@ -1,0 +1,14 @@
+<div class="row align-items-center">
+  <div class="col-auto">
+    <h6 class="font-weight-bold text-uppercase text-muted mb-0">Tags:</h6>
+  </div>
+  <div class="col ml-n5">
+    {% for p in site.pages %}
+        {% if p.category %}
+            <a class="badge badge-pill badge-secondary-soft" href="/articles/{{ p.category.slug }}/">
+                <span class="h6 text-uppercase">{{ p.category.name }}</span>
+            </a>
+        {% endif %}
+    {% endfor %}
+  </div>
+</div>

--- a/_includes/category-section.html
+++ b/_includes/category-section.html
@@ -1,0 +1,15 @@
+<section class="pt-7 pt-md-10 pb-10 pb-md-13">
+    <div class="container">
+      <div class="row align-items-center mb-5">
+        <div class="col-12 col-md">
+          <!-- Heading -->
+          <h1 class="mb-0">
+            {{ include.category.name }}
+          </h1>
+        </div>
+      </div> <!-- / .row -->
+      <div class="row">
+        {%- include posts-category.html category=include.category -%}
+      </div>
+    </div> <!-- / .container -->
+  </section>

--- a/_includes/posts-category.html
+++ b/_includes/posts-category.html
@@ -1,0 +1,9 @@
+{% comment %}
+  Get posts that are in a specific category
+{% endcomment %}
+
+{% for post in site.posts %}
+    {% if post.categories contains include.category.slug %}
+        {%- include post-regular.html post=post -%}
+    {% endif %}
+{% endfor %}

--- a/_layouts/articles.html
+++ b/_layouts/articles.html
@@ -1,0 +1,41 @@
+---
+layout: default
+---
+
+<!-- WELCOME
+    ================================================== -->
+    <section data-jarallax data-speed=".8" class="py-10 py-md-14 bg-cover jarallax" style="background-image: url(/assets/img/covers/articles.jpg);">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-12 col-md-10 col-lg-7 text-center">
+            
+            <!-- Heading -->
+            <h1 class="display-2 font-weight-bold text-white">
+              Articles
+            </h1>
+
+            <!-- Text -->
+            <p class="lead mb-0 text-white-75">
+              My thoughts, experience and knowledge as a memory dump.
+            </p>
+
+          </div>
+        </div> <!-- / .row -->
+      </div> <!-- / .container -->
+    </section>
+
+    <!-- SHAPE
+    ================================================== -->
+    <div class="position-relative">
+      <div class="shape shape-bottom shape-fluid-x svg-shim text-white">
+        {%- include assets/img/shapes/curves/curve-1.svg -%}
+      </div>
+    </div>
+
+    <section class="mt-7">
+      <div class="container">
+        {%- include article-categories.html -%}
+      </div>
+    </section>
+
+    {{ content }}

--- a/articles/experience/index.html
+++ b/articles/experience/index.html
@@ -1,0 +1,8 @@
+---
+layout: articles
+category:
+    name: Experience
+    slug: experience
+---
+
+{%- include category-section.html category=page.category -%}

--- a/articles/how_to/index.html
+++ b/articles/how_to/index.html
@@ -1,0 +1,8 @@
+---
+layout: articles
+category:
+    name: How To
+    slug: how_to
+---
+
+{%- include category-section.html category=page.category -%}

--- a/articles/index.html
+++ b/articles/index.html
@@ -1,20 +1,33 @@
 ---
-layout: default
+layout: articles
 title: Our Articles
 description: Articles page
 ---
 
-<!-- WELCOME
-    ================================================== -->
-    <section data-jarallax data-speed=".8" class="py-10 py-md-14 bg-cover jarallax" style="background-image: url(/assets/img/covers/articles.jpg);">
-      <div class="container">
-        <div class="row justify-content-center">
-          <div class="col-12 col-md-10 col-lg-7 text-center">
-            
-            <!-- Heading -->
-            <h1 class="display-2 font-weight-bold text-white">
-              Articles
-            </h1>
+<!-- ARTICLES
+================================================== -->
+<section class="pt-7 pt-md-10">
+  <div class="container">
+    {%- include posts-featured.html limit=3 -%}
+  </div> <!-- / .container -->
+</section>
+
+<!-- ARTICLES
+================================================== -->
+<section class="pt-7 pt-md-10 pb-10 pb-md-13">
+  <div class="container">
+    <div class="row align-items-center mb-5">
+      <div class="col-12 col-md">
+        
+        <!-- Heading -->
+        <h3 class="mb-0">
+          Latest Articles
+        </h3>
+
+        <!-- Text -->
+        <p class="mb-0 text-muted">
+          Some things that I learned over time.
+        </p>
 
             <!-- Text -->
             <p class="lead mb-0 text-white-75">
@@ -32,37 +45,9 @@ description: Articles page
       <div class="shape shape-bottom shape-fluid-x svg-shim text-light">
         {%- include assets/img/shapes/curves/curve-1.svg -%}
       </div>
+    </div> <!-- / .row -->
+    <div class="row">
+      {%- include posts-regular.html limit=1000 -%}
     </div>
-
-    <!-- ARTICLES
-    ================================================== -->
-    <section class="pt-7 pt-md-10">
-      <div class="container">
-        {%- include posts-featured.html limit=3 -%}
-      </div> <!-- / .container -->
-    </section>
-
-    <!-- ARTICLES
-    ================================================== -->
-    <section class="pt-7 pt-md-10 pb-10 pb-md-13">
-      <div class="container">
-        <div class="row align-items-center mb-5">
-          <div class="col-12 col-md">
-            
-            <!-- Heading -->
-            <h3 class="mb-0">
-              Latest Articles
-            </h3>
-
-            <!-- Text -->
-            <p class="mb-0 text-muted">
-              Some things that I learned over time.
-            </p>
-
-          </div>
-        </div> <!-- / .row -->
-        <div class="row">
-          {%- include posts-regular.html limit=1000 -%}
-        </div>
-      </div> <!-- / .container -->
-    </section>
+  </div> <!-- / .container -->
+</section>

--- a/articles/knowledge/index.html
+++ b/articles/knowledge/index.html
@@ -1,0 +1,8 @@
+---
+layout: articles
+category:
+    name: Knowledge
+    slug: knowledge
+---
+
+{%- include category-section.html category=page.category -%}


### PR DESCRIPTION
- 3 new pages for the 3 categories
- new layout called `articles` which the Articles home AND the 3 new category pages will use
- move common content from the Articles home into the `articles` layout
- new includes to render regular articles that match a given category
- add back the `Tags: X Y Z` component from the template (use the 3 new pages above to generate)
- closes #197