### PR TITLE
Expand beyond the default margins #195

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -106,20 +106,20 @@ layout: default
         <div class="row justify-content-center">
           <div class="col-12 col-md-10 col-lg-9 col-xl-8">
             {{ page.content }}
-            <!-- --- CONTACT FORM --- -->
             <h2>Sharing is Caring</h2>
             <p>If you found this article useful, consider sharing it with someone you think could benefit from it.</p>
-            
             <div class="contact_form">
               <h2>Contact David Today</h2>
               <p>Please describe your situation and your cloud computing needs.</p>
-              {% include contact_form.html select ="Industry" %}
             </div>
-            <!-- --- CONTACT FORM --- -->
           </div>
         </div> <!-- / .row -->
       </div> <!-- / .container -->
     </section>
+
+    <!-- --- CONTACT FORM --- -->
+    {% include contact_form.html select ="Industry" %}
+    <!-- --- CONTACT FORM --- -->
 
     <!-- ARTICLES
     ================================================== -->


### PR DESCRIPTION
- move the contact form (on an article) out of the main section and allow it to be on its own, for larger sizes it takes up more space
- closes #195