### PR TITLE
Justify the text #224

### DIFF
--- a/_includes/home_about.html
+++ b/_includes/home_about.html
@@ -34,7 +34,7 @@
             <div class="col-md-8">
 
               <!-- Body -->
-              <div class="card-body py-7 py-md-9 text-center">
+              <div class="card-body py-7 py-md-9 text-center text-lg-right">
 
                 <!-- Heading -->
                 <h4 class="font-weight-bold">
@@ -54,12 +54,12 @@
       <div class="col-12 col-lg-6 d-lg-flex pb-1 mb-4">
 
         <!-- Card 2 -->
-        <div class="card shadow-light-lg overflow-hidden text-center" data-aos="fade-up">
+        <div class="card shadow-light-lg overflow-hidden" data-aos="fade-up">
           <div class="row">
             <div class="col-md-8">
 
               <!-- Body -->
-              <div class="card-body py-7 py-md-9">
+              <div class="card-body py-7 py-md-9 text-center text-lg-left">
 
                 <!-- Heading -->
                 <h4 class="font-weight-bold">


### PR DESCRIPTION
- left and right align the text when we go `lg` - essentialy desktop, keep it centered otherwise for tablet and mobile
- move one of the style rules to be consistent with other
- closes #224