### PR TITLE
Gaps in the white paper section #230

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -115,7 +115,7 @@ layout: default
 
 <!-- FORM
     ================================================== -->
-    <section class="pt-8 pt-md-11 pb-8 pb-md-14">
+    <section class="pt-6 pt-md-8 pb-8 pb-md-14">
       <div class="container">
         <div class="row">
           <div class="col-12">

--- a/_layouts/client.html
+++ b/_layouts/client.html
@@ -47,7 +47,7 @@ layout: default
               </h4>
 
               <!-- Text -->
-              <p class="font-size-sm text-gray-800 mb-5">
+              <p class="font-size-sm text-gray-800 mb-0">
                 {{ page.info }}
               </p>
 
@@ -65,7 +65,7 @@ layout: default
                 </h4>
 
                 <!-- Text -->
-                <p class="font-size-sm text-gray-800">
+                <p class="font-size-sm text-gray-800 mb-0">
                   {{ page.opinion }}
                 </p>
 
@@ -80,7 +80,7 @@ layout: default
 
 <!-- FORM
     ================================================== -->
-    <section class="pt-8 pt-md-11 pb-8 pb-md-14">
+    <section class="pt-6 pt-md-8 pb-8 pb-md-14">
       <div class="container">
         <div class="row">
           <div class="col-12">


### PR DESCRIPTION
- adjust the padding at the top of the form (below the content) on the Client template so that it mirrors the padding above the content
- also tweak this same space on the Article template
- bonus, make the 2 Company Info & Company Testimonial paragraphs have no bottom margin so the box looks a bit nicer
- closes #230