### PR TITLE
Correct titles for all #249

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -10,7 +10,7 @@ name: AWS Cloud Consulting
 description: "Drive business growth with personalized AWS consulting through 0x4447 to implement cost-effective customer solutions built on scalable cloud infrastructure."
 author: David Gatti
 after-name: "0x4447"
-title-sep: ' | '
+title-sep: ' - '
 generator: Jekyll v4.1.1
 exclude:
   - .sass-cache/

--- a/_config.yaml
+++ b/_config.yaml
@@ -10,6 +10,7 @@ name: AWS Cloud Consulting
 description: "Drive business growth with personalized AWS consulting through 0x4447 to implement cost-effective customer solutions built on scalable cloud infrastructure."
 author: David Gatti
 after-name: "0x4447"
+title-sep: ' | '
 generator: Jekyll v4.1.1
 exclude:
   - .sass-cache/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,6 +26,7 @@
     <title>{{title}}</title>
 
     <meta name="generator" content="{{site.generator}}" />
+
     {%- if page.author -%}
     {%- assign author = page.author -%}
     {%- else -%}
@@ -52,7 +53,7 @@
     <meta property="article:modified_time" content="page.{{modified_time}}" />
     {%- endif -%}
     <meta name="author" content="{{author}}" />
-    <meta property="og:title" content="{{ title }}" />
+    <meta property="og:title" content="{{title}}" />
     <meta property="og:locale" content="{{lang}}" />
     <meta property="og:description" content="{{descr}}" />
     <meta property="og:url" content="{{page.url | absolute_url}}" />
@@ -64,7 +65,7 @@
  
     <meta name="twitter:creator" content="{{author}}">
     <meta http-equiv="content-language" content="en" />
-    <meta name="twitter:title" content="{{ title }}">
+    <meta name="twitter:title" content="{{title}}">
     {%- if page.description -%}
     <meta name="twitter:description" content="{{page.description}}">
     <meta name="twitter:card" content="summary_large_image">
@@ -104,7 +105,7 @@
     "@type":"Person",
     "name":"{{author}}"},
     "description":"{{descr}}",
-    "name":"{{ title }}","headline":"{{page.title}}","@context":"https://schema.org"}</script>
+    "name":"{{title}}","headline":"{{page.title}}","@context":"https://schema.org"}</script>
 
     <!-- favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,15 +14,18 @@
 
     {% feed_meta %}
 
+    {% comment %}title configuration{% endcomment %}
+    {% assign comboName = site.name | append: site.title-sep | append: site.after-name %}
     {% if page.layout == 'article' %}
-    {% assign title = page.title | append: " - " | append: site.after-name %}
-        {% elsif page.type == 'home' %}
-        {% assign title = site.name | append: ' - ' | append: site.after-name %}
-        {%- else -%}
-        {% assign title = site.name | append: " - " | append: page.title | append: " - " | append: site.after-name %}
-    {%- endif -%} 
-    <meta name="generator" content="{{site.generator}}" />
+        {% assign title = page.title | append: site.title-sep | append: comboName %}
+    {% elsif page.type == 'home' %}
+        {% assign title = comboName | append: site.title-sep | append: site.description %}
+    {%- else -%}
+        {% assign title = page.title | append: site.title-sep | append: comboName %}
+    {%- endif -%}
     <title>{{title}}</title>
+
+    <meta name="generator" content="{{site.generator}}" />
     {%- if page.author -%}
     {%- assign author = page.author -%}
     {%- else -%}
@@ -49,7 +52,7 @@
     <meta property="article:modified_time" content="page.{{modified_time}}" />
     {%- endif -%}
     <meta name="author" content="{{author}}" />
-    <meta property="og:title" content="{{title}}" />
+    <meta property="og:title" content="{{ title }}" />
     <meta property="og:locale" content="{{lang}}" />
     <meta property="og:description" content="{{descr}}" />
     <meta property="og:url" content="{{page.url | absolute_url}}" />
@@ -61,7 +64,7 @@
  
     <meta name="twitter:creator" content="{{author}}">
     <meta http-equiv="content-language" content="en" />
-    <meta name="twitter:title" content="{{title}}">
+    <meta name="twitter:title" content="{{ title }}">
     {%- if page.description -%}
     <meta name="twitter:description" content="{{page.description}}">
     <meta name="twitter:card" content="summary_large_image">
@@ -101,7 +104,7 @@
     "@type":"Person",
     "name":"{{author}}"},
     "description":"{{descr}}",
-    "name":"{{title}}","headline":"{{page.title}}","@context":"https://schema.org"}</script>
+    "name":"{{ title }}","headline":"{{page.title}}","@context":"https://schema.org"}</script>
 
     <!-- favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,14 +14,21 @@
 
     {% feed_meta %}
 
-    {% comment %}title configuration{% endcomment %}
-    {% assign comboName = site.name | append: site.title-sep | append: site.after-name %}
-    {% if page.layout == 'article' %}
-        {% assign title = page.title | append: site.title-sep | append: comboName %}
-    {% elsif page.type == 'home' %}
-        {% assign title = comboName | append: site.title-sep | append: site.description %}
-    {%- else -%}
-        {% assign title = page.title | append: site.title-sep | append: comboName %}
+    {% comment %} title configuration {% endcomment %}
+
+    {% if page.type == 'home' %}
+        {% assign title = site.name | append: site.title-sep | append: site.after-name %}
+    {% else %}
+        {% if page.layout == 'article' %}
+            {% assign title = page.title | append: site.title-sep | append: site.after-name %}
+        {% else %}
+            {% if page.layout == 'client' %}
+                {% assign title = page.subtitle | append: site.title-sep | append: site.after-name %}
+            {% else %}
+                {% comment %} default {% endcomment %}
+                {% assign title = page.title | append: site.title-sep | append: site.after-name %}
+            {%- endif -%}
+        {%- endif -%}
     {%- endif -%}
     <title>{{title}}</title>
 

--- a/articles/index.html
+++ b/articles/index.html
@@ -1,6 +1,6 @@
 ---
 layout: articles
-title: Our Articles
+title: Articles
 description: Articles page
 ---
 

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Contact Us
+title: Contact
 image: /assets/img/covers/contact.jpg
 description: Please describe your situation and how 0x4447 can meet your expectations.
 ---

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Schedule A Meeting
+title: Schedule
 image: /assets/img/covers/schedule.jpg
 description: Schedule a one-on-one meeting to for free.
 ---


### PR DESCRIPTION
- use ` | ` as a title separator
- bring the `site.description` in for the home page
- cleanup
- closes #249 